### PR TITLE
hotfix/패들-튕김-현상

### DIFF
--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import * as THREE from "three";
 import { useGame } from "../../context/GameContext";
 
+// todo: 1. 닉네임, 패들에 색깔 부여 2. 마우스 움직이면 카메라 각도 조정
 const PongScene = () => {
   const { tournamentConfig, ballTrajectory, paddleATrajectory, paddleBTrajectory, ballTrajectoryVersion } = useGame();
   const mountRef = useRef(null);

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -22,7 +22,7 @@ const PongScene = () => {
     if (currentSegmentIndex >= ballTrajectory.segments.length) return;
     const segment = ballTrajectory.segments[currentSegmentIndex];
 
-    const currentTime = Date.now() / 1000;
+    const currentTime = (Date.now() / 1000).toFixed(3);
     const eventElapsedTime = currentTime - ballTrajectory.t_event;
     const segmentElapsedTime = eventElapsedTime - segment.t_start;
 
@@ -44,7 +44,8 @@ const PongScene = () => {
 
     const paddle = paddleRef.current;
 
-    const elapsedTime = Date.now() / 1000 - paddleTrajectory.t_event;
+    const currentTime = (Date.now() / 1000).toFixed(3);
+    const elapsedTime = currentTime - paddleTrajectory.t_event;
     let newY = paddleTrajectory.y + paddleTrajectory.dy * elapsedTime;
 
     if (paddleTrajectory.dy > 0) {

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -284,29 +284,29 @@ const PongScene = () => {
 	오차 = |현재 y좌표값 - 데이터의 y좌표값|
 	(튕길 거면 한번에 튕기자)
 	*/
-  // todo: 추후 POS_MAX_ERROR값은 서버에서 받아오도록 수정
-  const POS_MAX_ERROR = 10;
-  // 패들 A의 위치 오차값을 확인하고, 오차값이 POS_MAX_ERROR를 넘으면 패들의 위치를 수정한다.
+  // 패들 A의 위치 오차값을 확인하고, 오차값이 network_max_deviation를 넘으면 패들의 위치를 수정한다.
   useEffect(() => {
-    if (paddleARef && paddleARef.current && paddleATrajectory) {
+    if (tournamentConfig && paddleARef && paddleARef.current && paddleATrajectory) {
       const paddle = paddleARef.current;
       const posErrorValue = Math.abs(paddle.position.y - paddleATrajectory.current.y);
-      if (posErrorValue <= POS_MAX_ERROR) {
+      const maxErrorValue = tournamentConfig.network_max_deviation;
+      if (posErrorValue <= maxErrorValue) {
         paddleATrajectory.y = paddle.position.y; // 에러가 허용 범위 내라면, 현 y좌표값을 그대로 사용
       }
     }
-  }, [paddleATrajectoryVersion]);
+  }, [paddleATrajectoryVersion, tournamentConfig]);
 
-  // 패들 B의 위치 오차값을 확인하고, 오차값이 POS_MAX_ERROR를 넘으면 패들의 위치를 수정한다.
+  // 패들 B의 위치 오차값을 확인하고, 오차값이 network_max_deviation를 넘으면 패들의 위치를 수정한다.
   useEffect(() => {
-    if (paddleBRef && paddleBRef.current && paddleBTrajectory) {
+    if (tournamentConfig && paddleBRef.current && paddleBTrajectory) {
       const paddle = paddleBRef.current;
       const posErrorValue = Math.abs(paddle.position.y - paddleBTrajectory.current.y);
-      if (posErrorValue <= POS_MAX_ERROR) {
+      const maxErrorValue = tournamentConfig.network_max_deviation;
+      if (posErrorValue <= maxErrorValue) {
         paddleBTrajectory.y = paddle.position.y; // 에러가 허용 범위 내라면, 현 y좌표값을 그대로 사용
       }
     }
-  }, [paddleBTrajectoryVersion]);
+  }, [paddleBTrajectoryVersion, tournamentConfig]);
 
   return <div ref={mountRef} style={{ width: "100%", height: "100%", overflow: "hidden" }} />;
 };

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -252,18 +252,23 @@ const PongScene = () => {
     // if (scene && renderer && camera && ballRef.current && ballTrajectory.current) {
     if (scene && renderer && camera) {
       let prevFrameRenderTime = (Date.now() / 1000).toFixed(3);
+      let animationId = null;
       const animate = () => {
         updateBallPosition(ballTrajectory.current);
         updatePaddlePosition(paddleATrajectory.current, paddleARef, prevFrameRenderTime);
         updatePaddlePosition(paddleBTrajectory.current, paddleBRef, prevFrameRenderTime);
         renderer.render(scene, camera);
-        requestAnimationFrame(animate);
         prevFrameRenderTime = (Date.now() / 1000).toFixed(3);
+        animationId = requestAnimationFrame(animate);
       };
 
-      requestAnimationFrame(animate);
+      animationId = requestAnimationFrame(animate);
+
+      return () => {
+        cancelAnimationFrame(animationId);
+      };
     }
-  }, [ballTrajectoryVersion, scene, renderer, camera]);
+  }, [ballTrajectoryVersion, paddleATrajectoryVersion, paddleBTrajectoryVersion, scene, renderer, camera]);
 
   useEffect(() => {
     currentSegmentIndexRef.current = 0;

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -60,7 +60,10 @@ const PongScene = () => {
     const currentTime = (Date.now() / 1000).toFixed(3);
     const elapsedTime = currentTime - paddleTrajectory.t_start;
     let newY = paddleTrajectory.y + paddleTrajectory.dy * elapsedTime;
-    console.log(paddleTrajectory.y, paddleTrajectory.dy, elapsedTime, newY);
+
+    console.log(paddleTrajectory);
+    console.log("elapsedTime: ", elapsedTime);
+    console.log("newY: ", newY);
 
     if (paddleTrajectory.dy > 0) {
       newY = Math.min(newY, tournamentConfig.y_max - tournamentConfig.len_paddle / 2);

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -61,10 +61,6 @@ const PongScene = () => {
     const elapsedTime = currentTime - paddleTrajectory.t_start;
     let newY = paddleTrajectory.y + paddleTrajectory.dy * elapsedTime;
 
-    console.log(paddleTrajectory);
-    console.log("elapsedTime: ", elapsedTime);
-    console.log("newY: ", newY);
-
     if (paddleTrajectory.dy > 0) {
       newY = Math.min(newY, tournamentConfig.y_max - tournamentConfig.len_paddle / 2);
     } else {

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -280,7 +280,7 @@ const PongScene = () => {
   useEffect(() => {
     if (paddleARef && paddleARef.current && paddleATrajectory) {
       const paddle = paddleARef.current;
-      const posErrorValue = paddle.position.y - paddleATrajectory.current.y;
+      const posErrorValue = Math.abs(paddle.position.y - paddleATrajectory.current.y);
       if (posErrorValue > POS_MAX_ERROR) {
         paddle.position.y = paddleATrajectory.current.y;
       }

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -89,7 +89,7 @@ const PongScene = () => {
 
     // 카메라 생성
     const newCamera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 10000);
-    newCamera.position.set(0, 0, 500);
+    newCamera.position.set(0, 0, 800);
     // newCamera.up.set(0, 0, 1); // 카메라의 업벡터를 z축으로 설정
     newCamera.lookAt(new THREE.Vector3(0, 0, 0));
     setCamera(newCamera);

--- a/src/components/game/PongScene.js
+++ b/src/components/game/PongScene.js
@@ -291,7 +291,7 @@ const PongScene = () => {
   useEffect(() => {
     if (paddleBRef && paddleBRef.current && paddleBTrajectory) {
       const paddle = paddleBRef.current;
-      const posErrorValue = paddle.position.y - paddleBTrajectory.current.y;
+      const posErrorValue = Math.abs(paddle.position.y - paddleBTrajectory.current.y);
       if (posErrorValue > POS_MAX_ERROR) {
         paddle.position.y = paddleBTrajectory.current.y;
       }

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -91,12 +91,12 @@ export const GameProvider = ({ children }) => {
   const [myPlayerData, setMyPlayerData] = useState({ id: null, host: false });
 
   // tournament data
-  const [tournamentConfig, setTournamentConfig] = useState(dummyTournamentConfig);
+  const [tournamentConfig, setTournamentConfig] = useState(null);
   const [bracketData, setBracketData] = useState(null);
 
   // todo: 추후 subgame context 로 분리
   // subgame data
-  const [subgameStatus, setSubgameStatus] = useState(dummySubgameStatus);
+  const [subgameStatus, setSubgameStatus] = useState(null);
 
   const ballTrajectory = useRef(null);
   const paddleATrajectory = useRef(null);

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -102,6 +102,8 @@ export const GameProvider = ({ children }) => {
   const paddleATrajectory = useRef(null);
   const paddleBTrajectory = useRef(null);
   const [ballTrajectoryVersion, setBallTrajectoryVersion] = useState(0);
+  const [paddleATrajectoryVersion, setPaddleATrajectoryVersion] = useState(0);
+  const [paddleBTrajectoryVersion, setPaddleBTrajectoryVersion] = useState(0);
 
   // socket namespace
   const [roomNamespace, setRoomNamespace] = useState("");
@@ -230,6 +232,8 @@ export const GameProvider = ({ children }) => {
         console.log("ended 이벤트 수신: ", data);
         setSubgameStatus((prevState) => ({ ...prevState, progress: "ended", winner: data.winner }));
         setBallTrajectoryVersion(0);
+        setPaddleATrajectoryVersion(0);
+        setPaddleBTrajectoryVersion(0);
         disconnectSubgameSocket();
       },
     },
@@ -279,8 +283,10 @@ export const GameProvider = ({ children }) => {
         // console.log("update_track_paddle 이벤트 수신: ", data);
         if (data.player === "A") {
           paddleATrajectory.current = data;
+          setPaddleATrajectoryVersion((version) => version + 1);
         } else if (data.player === "B") {
           paddleBTrajectory.current = data;
+          setPaddleBTrajectoryVersion((version) => version + 1);
         }
       },
     },
@@ -478,6 +484,8 @@ export const GameProvider = ({ children }) => {
         paddleATrajectory,
         paddleBTrajectory,
         ballTrajectoryVersion,
+        paddleATrajectoryVersion,
+        paddleBTrajectoryVersion,
         // function
         getMyFinalSubgameAndRank,
         // socket

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -281,6 +281,7 @@ export const GameProvider = ({ children }) => {
       event: "update_track_paddle",
       handler: (data) => {
         // console.log("update_track_paddle 이벤트 수신: ", data);
+        data.t_start = (Date.now() / 1000).toFixed(3);
         if (data.player === "A") {
           paddleATrajectory.current = data;
           setPaddleATrajectoryVersion((version) => version + 1);

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -96,7 +96,17 @@ export const GameProvider = ({ children }) => {
 
   // todo: 추후 subgame context 로 분리
   // subgame data
-  const [subgameStatus, setSubgameStatus] = useState(null);
+  const [subgameStatus, setSubgameStatus] = useState({
+    progress: "none", // "none", "waiting", "playing", "ended"
+    time_start: null,
+    time_before_start: 0,
+    time_left: 0,
+    player_a: null,
+    player_b: null,
+    winner: "",
+    score_a: 0,
+    score_b: 0,
+  });
 
   const ballTrajectory = useRef(null);
   const paddleATrajectory = useRef(null);


### PR DESCRIPTION
문제 상황: 데이터 수신 딜레이로 인해 현재 렌더되어 있는 패들의 좌표와 옳은 패들의 좌표 값 사이에 차이가 생기고, 이로 인해 매번 패들이 튕겨보이는 현상 발생

변경된 패들 애니메이션 로직:
- 패들 좌표 오차 값이 허용 범위 이내인 경우, 현재 패들의 좌표를 유지
- 허용 범위 이내가 아닌 경우, 좌표 값을 옳은 값으로 조정 (한번에 튕김)